### PR TITLE
3.0 - remove request manager, use Nimbus.configuration

### DIFF
--- a/Application/Sources/Demand/APS/APS+Initialization.swift
+++ b/Application/Sources/Demand/APS/APS+Initialization.swift
@@ -17,7 +17,7 @@ extension UIApplicationDelegate {
             DTBAds.sharedInstance().setAppKey(appKey)
             DTBAds.sharedInstance().mraidPolicy = CUSTOM_MRAID
             DTBAds.sharedInstance().mraidCustomVersions = ["1.0", "2.0", "3.0"]
-            DTBAds.sharedInstance().testMode = Nimbus.shared.testMode
+            DTBAds.sharedInstance().testMode = Nimbus.configuration.testMode
             #if DEBUG
             DTBAds.sharedInstance().setLogLevel(DTBLogLevelDebug)
             #endif

--- a/Application/Sources/DynamicPrice/GAMBannerViewController.swift
+++ b/Application/Sources/DynamicPrice/GAMBannerViewController.swift
@@ -17,7 +17,6 @@ import GoogleMobileAds
 class GAMBannerViewController: GAMBaseViewController {
     private static let refreshInterval: TimeInterval = 30
     private let bannerView = AdManagerBannerView(adSize: AdSizeBanner)
-    private let requestManager = NimbusRequestManager()
     
     private var refreshTimer: Timer?
     

--- a/Application/Sources/DynamicPrice/GAMRewardedInterstitialViewController.swift
+++ b/Application/Sources/DynamicPrice/GAMRewardedInterstitialViewController.swift
@@ -93,18 +93,3 @@ extension GAMRewardedInterstitialViewController: AdMetadataDelegate {
         }
     }
 }
-
-// MARK: - NimbusRequestManagerDelegate
-
-extension GAMRewardedInterstitialViewController: NimbusRequestManagerDelegate {
-    func didCompleteNimbusRequest(request: NimbusRequest, ad: NimbusAd) {
-        print("didCompleteNimbusRequest")
-        
-        
-    }
-    
-    func didFailNimbusRequest(request: NimbusRequest, error: NimbusError) {
-        print("didFailNimbusRequest: \(error.localizedDescription)")
-    }
-    
-}

--- a/Application/Sources/DynamicPrice/GAMRewardedViewController.swift
+++ b/Application/Sources/DynamicPrice/GAMRewardedViewController.swift
@@ -93,19 +93,3 @@ extension GAMRewardedViewController: @preconcurrency AdMetadataDelegate {
         }
     }
 }
-
-// MARK: - NimbusRequestManagerDelegate
-
-extension GAMRewardedViewController: NimbusRequestManagerDelegate {
-    func didCompleteNimbusRequest(request: NimbusRequest, ad: NimbusAd) {
-        print("didCompleteNimbusRequest")
-        
-        
-    }
-    
-    func didFailNimbusRequest(request: NimbusRequest, error: NimbusError) {
-        print("didFailNimbusRequest: \(error.localizedDescription)")
-    }
-    
-}
-

--- a/Application/Sources/Helpers/ExtensionHelper.swift
+++ b/Application/Sources/Helpers/ExtensionHelper.swift
@@ -13,12 +13,12 @@ import Foundation
 /// it's not something a client app would normally do.
 struct ExtensionHelper {
     static var enabledState: [ObjectIdentifier: Bool] {
-        Nimbus.shared.extensions.mapValues { $0.enabled }
+        Nimbus.extensions.mapValues { $0.enabled }
     }
     
     static func disableAllExtensions(except: NimbusExtension.Type? = nil) {
         Task { @MainActor in
-            for (key, ext) in Nimbus.shared.extensions {
+            for (key, ext) in Nimbus.extensions {
                 if except == nil || key != ObjectIdentifier(except!) {
                     type(of: ext).disable()
                 }
@@ -29,7 +29,7 @@ struct ExtensionHelper {
     static func restoreExtensionsState(from: [ObjectIdentifier: Bool]) {
         Task { @MainActor in
             for (extType, enabled) in from {
-                guard let ext = Nimbus.shared.extensions[extType] else {
+                guard let ext = Nimbus.extensions[extType] else {
                     continue
                 }
                 

--- a/Application/Sources/Initialization.swift
+++ b/Application/Sources/Initialization.swift
@@ -72,21 +72,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        Nimbus.shared.testMode = UserDefaults.standard.nimbusTestMode
-        Nimbus.shared.coppa = UserDefaults.standard.coppaOn
+        Nimbus.configuration.testMode = UserDefaults.standard.nimbusTestMode
+        Nimbus.configuration.coppa = UserDefaults.standard.coppaOn
         
         // This is only for testing environment, do NOT add this on production environment
         if let mockServerUrl = ProcessInfo.processInfo.environment["MOCK_SERVER_URL"] {
-            NimbusRequestManager.requestUrl = URL(string: mockServerUrl)!
-        } else if Nimbus.shared.testMode {
-            NimbusRequestManager.requestUrl = URL(string: "https://\(Nimbus.shared.publisher).adsbynimbus.com/rta/test")!
-            NimbusRequestManager.additionalRequestHeaders = [
+            Nimbus.configuration.requestUrl = URL(string: mockServerUrl)!
+        } else if Nimbus.configuration.testMode {
+            Nimbus.configuration.requestUrl = URL(string: "https://\(publisher).adsbynimbus.com/rta/test")!
+            Nimbus.configuration.additionalRequestHeaders = [
                 "Nimbus-Test-No-Fill": String(UserDefaults.standard.forceNoFill)
             ]
         }
 
         // User
-        NimbusRequestManager.user = NimbusUser(age: 20, gender: .male)
+        Nimbus.configuration.user = NimbusUser(age: 20, gender: .male)
     }
     
     private func startTrackingATT() {

--- a/Application/Sources/Settings.swift
+++ b/Application/Sources/Settings.swift
@@ -125,7 +125,7 @@ extension UserDefaults {
                 user.configureGdprConsent(consentString: testGDPRConsentString)
                 Nimbus.configuration.user = user
             } else {
-                Nimbus.configuration.user?.extensions?.removeValue(forKey: "consent")
+                Nimbus.configuration.user?.extensions.removeValue(forKey: "consent")
             }
         }
     }

--- a/Application/Sources/Settings.swift
+++ b/Application/Sources/Settings.swift
@@ -88,6 +88,7 @@ enum GeneralSettings: String, SettingsEnum, CaseIterable {
 
 // Nimbus Test Mode
 extension UserDefaults {
+    @MainActor
     var nimbusTestMode: Bool {
         get {
             register(defaults: [#function: true])
@@ -95,10 +96,11 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: #function)
-            Nimbus.shared.testMode = newValue
+            Nimbus.configuration.testMode = newValue
         }
     }
     
+    @MainActor
     var coppaOn: Bool {
         get {
             register(defaults: [#function: false])
@@ -106,7 +108,7 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: #function)
-            Nimbus.shared.coppa = newValue
+            Nimbus.configuration.coppa = newValue
         }
     }
     
@@ -118,12 +120,12 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: #function)
-            if newValue, var user = NimbusRequestManager.user {
+            if newValue, var user = Nimbus.configuration.user {
                 // Same string as Android sample app
                 user.configureGdprConsent(consentString: testGDPRConsentString)
-                NimbusRequestManager.user = user
+                Nimbus.configuration.user = user
             } else {
-                NimbusRequestManager.user?.extensions?.removeValue(forKey: "consent")
+                Nimbus.configuration.user?.extensions?.removeValue(forKey: "consent")
             }
         }
     }
@@ -184,7 +186,7 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: #function)
-            NimbusRequestManager.additionalRequestHeaders["Nimbus-Test-No-Fill"] = String(newValue)
+            Nimbus.configuration.additionalRequestHeaders["Nimbus-Test-No-Fill"] = String(newValue)
         }
     }
     

--- a/Application/Sources/Settings.swift
+++ b/Application/Sources/Settings.swift
@@ -125,7 +125,7 @@ extension UserDefaults {
                 user.configureGdprConsent(consentString: testGDPRConsentString)
                 Nimbus.configuration.user = user
             } else {
-                Nimbus.configuration.user?.extensions.removeValue(forKey: "consent")
+                Nimbus.configuration.user?.extensions?.removeValue(forKey: "consent")
             }
         }
     }

--- a/Application/Sources/UI/MobileFuseViewController.swift
+++ b/Application/Sources/UI/MobileFuseViewController.swift
@@ -20,7 +20,7 @@ import NimbusMobileFuseKit
 class MobileFuseViewController: SampleAdViewController {
     
     deinit {
-        Task { @MainActor in NimbusRequestManager.removeMobileFuseHeader() }
+        Task { @MainActor in Nimbus.removeMobileFuseHeader() }
     }
     
     init(headerTitle: String, headerSubTitle: String) {
@@ -34,6 +34,6 @@ class MobileFuseViewController: SampleAdViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NimbusRequestManager.insertMobileFuseHeader()
+        Nimbus.insertMobileFuseHeader()
     }
 }

--- a/Application/Sources/UI/NimbusRequestManager+MobileFuse.swift
+++ b/Application/Sources/UI/NimbusRequestManager+MobileFuse.swift
@@ -12,12 +12,12 @@ private let enableMobileFuseHeaderKey = "Nimbus-Test-EnableMobileFuseSDK"
 
 ///  Nimbus test endpoint header manipulation. This is NOT something to do in production environment.
 @MainActor
-extension NimbusRequestManager {
+extension Nimbus {
     static func insertMobileFuseHeader() {
-        NimbusRequestManager.additionalRequestHeaders[enableMobileFuseHeaderKey] = "true"
+        Nimbus.configuration.additionalRequestHeaders[enableMobileFuseHeaderKey] = "true"
     }
     
     static func removeMobileFuseHeader() {
-        NimbusRequestManager.additionalRequestHeaders.removeValue(forKey: enableMobileFuseHeaderKey)
+        Nimbus.configuration.additionalRequestHeaders.removeValue(forKey: enableMobileFuseHeaderKey)
     }
 }


### PR DESCRIPTION
Removes NimbusRequestManager and moves all configuration under Nimbus.configuration