### PR TITLE
Unify extension imports

### DIFF
--- a/Application/Sources/Demand/APS/APSBannerViewController.swift
+++ b/Application/Sources/Demand/APS/APSBannerViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 import DTBiOSSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAPSKit) // Swift Package Manager
 import NimbusAPSKit
-#endif
 
 class APSBannerViewController: SampleAdViewController {
     

--- a/Application/Sources/Demand/APS/APSInterstitialViewController.swift
+++ b/Application/Sources/Demand/APS/APSInterstitialViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 import DTBiOSSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAPSKit) // Swift Package Manager
 import NimbusAPSKit
-#endif
 
 class APSInterstitialViewController: SampleAdViewController {
     

--- a/Application/Sources/Demand/AdMob/AdMobBannerViewController.swift
+++ b/Application/Sources/Demand/AdMob/AdMobBannerViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAdMobKit) // Swift Package Manager
 import NimbusAdMobKit
-#endif
 
 private let bannerPlacementId = Bundle.main.infoDictionary?["AdMob Banner ID"] as? String ?? ""
 

--- a/Application/Sources/Demand/AdMob/AdMobInterstitialViewController.swift
+++ b/Application/Sources/Demand/AdMob/AdMobInterstitialViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAdMobKit) // Swift Package Manager
 import NimbusAdMobKit
-#endif
 
 private let interstitialPlacementId = Bundle.main.infoDictionary?["AdMob Interstitial ID"] as? String ?? ""
 

--- a/Application/Sources/Demand/AdMob/AdMobNativeViewController.swift
+++ b/Application/Sources/Demand/AdMob/AdMobNativeViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 import GoogleMobileAds
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAdMobKit) // Swift Package Manager
 import NimbusAdMobKit
-#endif
 
 let nativePlacementId = Bundle.main.infoDictionary?["AdMob Native ID"] as? String ?? ""
 

--- a/Application/Sources/Demand/AdMob/AdMobRewardedViewController.swift
+++ b/Application/Sources/Demand/AdMob/AdMobRewardedViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAdMobKit) // Swift Package Manager
 import NimbusAdMobKit
-#endif
 
 private let rewardedPlacementId = Bundle.main.infoDictionary?["AdMob Rewarded ID"] as? String ?? ""
 

--- a/Application/Sources/Demand/InMobi/InMobiBannerViewController.swift
+++ b/Application/Sources/Demand/InMobi/InMobiBannerViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusInMobiKit
-#endif
 
 final class InMobiBannerViewController: InMobiViewController {
 

--- a/Application/Sources/Demand/InMobi/InMobiInterstitialViewController.swift
+++ b/Application/Sources/Demand/InMobi/InMobiInterstitialViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusInMobiKit
-#endif
 
 final class InMobiInterstitialViewController: InMobiViewController {
 

--- a/Application/Sources/Demand/InMobi/InMobiRewardedViewController.swift
+++ b/Application/Sources/Demand/InMobi/InMobiRewardedViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusInMobiKit
-#endif
 
 final class InMobiRewardedViewController: InMobiViewController {
 

--- a/Application/Sources/Demand/Mintegral/MintegralBannerViewController.swift
+++ b/Application/Sources/Demand/Mintegral/MintegralBannerViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 class MintegralBannerViewController: MintegralViewController {
     var bannerAd: InlineAd?

--- a/Application/Sources/Demand/Mintegral/MintegralInterstitialViewController.swift
+++ b/Application/Sources/Demand/Mintegral/MintegralInterstitialViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 class MintegralInterstitialViewController: MintegralViewController {
     var interstitialAd: InterstitialAd?

--- a/Application/Sources/Demand/Mintegral/MintegralNativeViewController.swift
+++ b/Application/Sources/Demand/Mintegral/MintegralNativeViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 import MTGSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 class MintegralNativeViewController: MintegralViewController {
     var nativeAd: InlineAd?

--- a/Application/Sources/Demand/Mintegral/MintegralRewardedViewController.swift
+++ b/Application/Sources/Demand/Mintegral/MintegralRewardedViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 class MintegralRewardedViewController: MintegralViewController {
     var rewardedAd: RewardedAd?

--- a/Application/Sources/Demand/MobileFuse/MobileFuseBannerViewController.swift
+++ b/Application/Sources/Demand/MobileFuse/MobileFuseBannerViewController.swift
@@ -8,11 +8,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMobileFuseKit) // Swift Package Manager
 import NimbusMobileFuseKit
-#endif
 
 final class MobileFuseBannerViewController: MobileFuseViewController {
     

--- a/Application/Sources/Demand/MobileFuse/MobileFuseInterstitialViewController.swift
+++ b/Application/Sources/Demand/MobileFuse/MobileFuseInterstitialViewController.swift
@@ -8,11 +8,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMobileFuseKit) // Swift Package Manager
 import NimbusMobileFuseKit
-#endif
 
 final class MobileFuseInterstitialViewController: MobileFuseViewController {
     private var interstitialAd: InterstitialAd?

--- a/Application/Sources/Demand/MobileFuse/MobileFuseRewardedViewController.swift
+++ b/Application/Sources/Demand/MobileFuse/MobileFuseRewardedViewController.swift
@@ -8,11 +8,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMobileFuseKit) // Swift Package Manager
 import NimbusMobileFuseKit
-#endif
 
 final class MobileFuseRewardedViewController: MobileFuseViewController {
     private var rewardedAd: RewardedAd?

--- a/Application/Sources/Demand/Moloco/MolocoBannerViewController.swift
+++ b/Application/Sources/Demand/Moloco/MolocoBannerViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 final class MolocoBannerViewController: MolocoViewController {
 

--- a/Application/Sources/Demand/Moloco/MolocoInterstitialViewController.swift
+++ b/Application/Sources/Demand/Moloco/MolocoInterstitialViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 final class MolocoInterstitialViewController: MolocoViewController {
 

--- a/Application/Sources/Demand/Moloco/MolocoNativeViewController.swift
+++ b/Application/Sources/Demand/Moloco/MolocoNativeViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 import MolocoSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 fileprivate var adUnitId = Bundle.main.infoDictionary?["Moloco Native ID"] as! String
 

--- a/Application/Sources/Demand/Moloco/MolocoRewardedViewController.swift
+++ b/Application/Sources/Demand/Moloco/MolocoRewardedViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 final class MolocoRewardedViewController: MolocoViewController {
 

--- a/Application/Sources/Demand/Vungle.swift
+++ b/Application/Sources/Demand/Vungle.swift
@@ -8,11 +8,7 @@
 
 import AdSupport
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusVungleKit
-#endif
 import UIKit
 import VungleAdsSDK
 

--- a/Application/Sources/Initialization.swift
+++ b/Application/Sources/Initialization.swift
@@ -9,10 +9,6 @@ import AppTrackingTransparency
 import NimbusKit
 import SwiftUI
 import UIKit
-
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusVungleKit
 import NimbusMobileFuseKit
 import NimbusMintegralKit
@@ -21,7 +17,6 @@ import NimbusMetaKit
 import NimbusUnityKit
 import NimbusMolocoKit
 import NimbusInMobiKit
-#endif
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Application/Sources/UI/AdMobViewController.swift
+++ b/Application/Sources/UI/AdMobViewController.swift
@@ -8,11 +8,7 @@
 import UIKit
 import NimbusKit
 
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusAdMobKit) // Swift Package Manager
 import NimbusAdMobKit
-#endif
 
 ///  When integrating AdMob, consider examples like AdMobBannerViewController inherit from UIViewController.
 ///  Both DemandViewController and AdMobViewController just facilitate the needs of the sample app.

--- a/Application/Sources/UI/InMobiViewController.swift
+++ b/Application/Sources/UI/InMobiViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusInMobiKit
-#endif
 
 ///  When integrating InMobi, consider examples like InMobiBannerViewController inherit from UIViewController.
 ///  Both SampleAdViewController and InMobiViewController just facilitate the needs of the sample app.

--- a/Application/Sources/UI/MintegralNativeAdView.swift
+++ b/Application/Sources/UI/MintegralNativeAdView.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import MTGSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 final class MintegralNativeAdView: UIView, MintegralNativeAdViewType {
     let mediaView: MTGMediaView = {

--- a/Application/Sources/UI/MintegralViewController.swift
+++ b/Application/Sources/UI/MintegralViewController.swift
@@ -5,11 +5,7 @@
 //  Copyright © 2024 Nimbus Advertising Solutions Inc. All rights reserved.
 //
 
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMintegralKit) // Swift Package Manager
 import NimbusMintegralKit
-#endif
 
 ///  When integrating Mintegral, consider examples like MintegralBannerViewController inherit from UIViewController.
 ///  Both SampleAdViewController and MintegralViewController just facilitate the needs of the sample app.

--- a/Application/Sources/UI/MobileFuseViewController.swift
+++ b/Application/Sources/UI/MobileFuseViewController.swift
@@ -9,11 +9,7 @@
 import UIKit
 import NimbusKit
 
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMobileFuseKit) // Swift Package Manager
 import NimbusMobileFuseKit
-#endif
 
 ///  When integrating MobileFuse, consider examples like MobileFuseBannerViewController inherit from UIViewController.
 ///  Both SampleAdViewController and MobileFuseViewController just facilitate the needs of the sample app.

--- a/Application/Sources/UI/MolocoNativeAdView.swift
+++ b/Application/Sources/UI/MolocoNativeAdView.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import MolocoSDK
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 final class MolocoNativeAdView: UIView, NimbusMolocoNativeAdViewType {
     

--- a/Application/Sources/UI/MolocoViewController.swift
+++ b/Application/Sources/UI/MolocoViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 import NimbusKit
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#elseif canImport(NimbusMolocoKit) // Swift Package Manager
 import NimbusMolocoKit
-#endif
 
 ///  When integrating Moloco, consider examples like MolocoBannerViewController inherit from UIViewController.
 ///  Both SampleAdViewController and MolocoViewController just facilitate the needs of the sample app.

--- a/Application/Sources/UI/NimbusVungleNativeAdView.swift
+++ b/Application/Sources/UI/NimbusVungleNativeAdView.swift
@@ -9,11 +9,7 @@ import UIKit
 import VungleAdsSDK
 import NimbusKit
 
-#if canImport(NimbusSDK) // CocoaPods
-import NimbusSDK
-#else                    // Swift Package Manager
 import NimbusVungleKit
-#endif
 
 /// Nimbus default view used for Vungle native ads
 final class NimbusVungleNativeAdView: UIView, NimbusVungleNativeAdViewType {


### PR DESCRIPTION
This PR removes `import NimbusSDK` which is not necessary anymore as CocoaPods dependencies will have the same import module as SPM